### PR TITLE
Filter custom dimension names

### DIFF
--- a/src/main/java/io/xol/enklume/MinecraftWorld.java
+++ b/src/main/java/io/xol/enklume/MinecraftWorld.java
@@ -82,9 +82,11 @@ public class MinecraftWorld {
     public List<Integer> getDimensionIds() throws IOException {
         List<Integer> dimensionIds = Files.walk(this.folder.toPath(), 1)
                 .filter(Files::isDirectory)
-                .filter(path -> path.getFileName().toString().startsWith("DIM"))
-                .filter(path -> isInteger(path.getFileName().toString()))
-                .map(dimensionFolder -> Integer.parseInt(dimensionFolder.getFileName().toString().substring(3)))
+                .map(path -> path.getFileName().toString())
+                .filter(path -> path.startsWith("DIM"))
+                .map(path -> path.substring(3))
+                .filter(dimensionId -> isInteger(dimensionId))
+                .map(dimensionId -> Integer.parseInt(dimensionId))
                 .collect(Collectors.toList());
         dimensionIds.add(0);
         return dimensionIds;


### PR DESCRIPTION
I've got a [crash report](https://github.com/SinTh0r4s/VisualProspecting/issues/7) where some Minecraft mod used custom dimension folders. Quick filter to skip those dimensions.

Btw: VisualProspecting will soon be release in GregTech: New Horizons and spread your lib to thousands of players ;-)